### PR TITLE
add extra indicies to msg

### DIFF
--- a/src/keyboard/k8890.rs
+++ b/src/keyboard/k8890.rs
@@ -170,7 +170,7 @@ impl Keyboard8890 {
         let kc: Vec<_> = key_chord.split(',').collect();
         let mut prepended = false;
         for (i, key) in kc.iter().enumerate() {
-            let mut msg = vec![0x03, key_pos, 0x00, 0x00];
+            let mut msg = vec![0x03, key_pos, 0x00, 0x00, 0x00, 0x00, 0x00];
             let mut remaining = consts::PACKET_SIZE - msg.len();
             let km: Vec<_> = key.split('-').collect();
             let mut mouse_action = 0u8;


### PR DESCRIPTION
I do not know rust nor do I understand most of the code, but this solved an issue for me. I assume there is a better way of doing this...

Had issue when programming wheelup/wheeldown into macropad and received error about line 212 accessing index out of bounds.