### PR TITLE
Reject multi-layer mapping.ron on 8890 instead of silent collapse

### DIFF
--- a/src/keyboard/k8890.rs
+++ b/src/keyboard/k8890.rs
@@ -56,6 +56,20 @@ impl Keyboard for Keyboard8890 {
         // FIXME: currently hardcoding the layer to 1 as the only 8890 device
         //        i have seen only has support for one layer. if we know of
         //        one that has multiple layers, we should refactor this then
+        //
+        // Until multi-layer support is confirmed for this device, reject configs
+        // with more than one layer rather than silently writing them all to the
+        // same physical slot (where the last layer wins and earlier layers are
+        // lost without warning).
+        if macropad.layers.len() > 1 {
+            return Err(anyhow!(
+                "this device is driven as single-layer but the provided configuration has {} layers. \
+                 all layers would be written to the same physical slot, silently overwriting earlier \
+                 layers. please reduce your mapping.ron to a single layer for the 8890",
+                macropad.layers.len()
+            ));
+        }
+
         self.send(&self.begin_programming(1))?;
 
         // get our layout of buttons relative to programming orientation


### PR DESCRIPTION
## Summary
- Rejects multi-layer `mapping.ron` on the 1189:8890 with a clear error, instead of silently collapsing every layer into the last-written one.
- Preserves existing behavior for single-layer configurations.
- Addresses the first item from #50.

## Context
The 8890 driver calls `begin_programming(1)` once and then iterates all layers from the config, writing each to the same physical slot derived only from row/col/knob position. When the user provides more than one layer, earlier layers are silently overwritten by the last one — and the program still reports `successfully programmed device`.

The existing `FIXME` comment in `src/keyboard/k8890.rs` already flags that this needs a real refactor if the 8890 actually supports multiple layers. Until someone confirms that (ideally from a vendor-tool packet capture), silent data loss is worse than a hard error.

## Test plan
- [x] `cargo build --release` builds cleanly on rustc 1.94.1
- [x] Single-layer `mapping.ron` still programs successfully on 1189:8890 (Ubuntu 25.10)
- [x] Multi-layer `mapping.ron` now returns the new error with layer count instead of reporting success

🤖 Generated with [Claude Code](https://claude.com/claude-code)